### PR TITLE
Add SQL Server support

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -30,3 +30,12 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  db_mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    # command: ["/opt/mssql-tools/bin/sqlcmd", "-S localhost -U sa -P StrongPassw0rd -d test_db", "&&", "/opt/mssql/bin/sqlservr"]
+    ports:
+      - "1433:1433"
+    environment:
+      ACCEPT_EULA: 'Y'
+      MSSQL_SA_PASSWORD: 'StrongPassw0rd'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,8 @@
         <env name="KERNEL_CLASS" value="Talleu\TriggerMapping\Tests\Application\Kernel"/>
         <!--  To switch plateform   from mysql to postgre     -->
         <env name="DATABASE_URL" value="mysql://test_user:test_password@127.0.0.1:3308/test_db?serverVersion=8.0"/>
-<!--        <env name="DATABASE_URL" value="postgresql://test_user:test_password@127.0.0.1:5433/test_db?serverVersion=15"/>-->
+        <!--<env name="DATABASE_URL" value="postgresql://test_user:test_password@127.0.0.1:5433/test_db?serverVersion=15"/>-->
+        <!--<env name="DATABASE_URL" value="pdo-sqlsrv://sa:StrongPassw0rd@127.0.0.1:1433/test_db?serverVersion=2022&amp;charset=UTF-8"/>-->
     </php>
 
     <testsuites>
@@ -24,6 +25,9 @@
         </testsuite>
         <testsuite name="postgresql">
             <directory>tests/Functional/Postgresql</directory>
+        </testsuite>
+        <testsuite name="sqlserver">
+            <directory>tests/Functional/SqlServer</directory>
         </testsuite>
         <testsuite name="unit">
             <directory>tests/Unit</directory>

--- a/src/DatabaseSchema/TriggersDbExtractor.php
+++ b/src/DatabaseSchema/TriggersDbExtractor.php
@@ -38,7 +38,7 @@ final readonly class TriggersDbExtractor implements TriggersDbExtractorInterface
 
             $rawTriggers = $connection->fetchAllAssociative($sql);
             $triggers = $this->normalizeMysqlTriggers($rawTriggers);
-        } else if ($this->databasePlatformResolver->isSQLServer()) {
+        } elseif ($this->databasePlatformResolver->isSQLServer()) {
             $sql = "SELECT 
                         T.name AS name,
                         T.object_id AS id,
@@ -54,7 +54,7 @@ final readonly class TriggersDbExtractor implements TriggersDbExtractorInterface
                     ON T.parent_id = O.object_id
                     LEFT JOIN sys.trigger_event_types AS TT
                     ON TE.type = TT.type";
-                    
+
 
             $rawTriggers = $connection->fetchAllAssociative($sql);
             $triggers = $this->normalizeSqlServerTriggers($rawTriggers);

--- a/src/Platform/DatabasePlatformResolver.php
+++ b/src/Platform/DatabasePlatformResolver.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 
 final readonly class DatabasePlatformResolver implements DatabasePlatformResolverInterface
 {
@@ -28,11 +29,20 @@ final readonly class DatabasePlatformResolver implements DatabasePlatformResolve
         return $this->getPlatform() instanceof AbstractMySQLPlatform;
     }
 
+    public function isSQLServer(): bool
+    {
+        return $this->getPlatform() instanceof SQLServerPlatform;
+    }
+
 
     public function getPlatformName(): string
     {
         if ($this->isMySQL()) {
             return 'mysql';
+        }
+
+        if ($this->isSQLServer()) {
+            return 'sqlsrv';
         }
 
         return 'postgresql';

--- a/src/Platform/DatabasePlatformResolverInterface.php
+++ b/src/Platform/DatabasePlatformResolverInterface.php
@@ -10,5 +10,7 @@ interface DatabasePlatformResolverInterface
 
     public function isPostgreSQL(): bool;
 
+    public function isSQLServer(): bool;
+
     public function getPlatformName(): string;
 }

--- a/src/Symfony/Maker/Resources/skeleton/php/SqlServerTrigger.tpl.php
+++ b/src/Symfony/Maker/Resources/skeleton/php/SqlServerTrigger.tpl.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+echo "<?php\n"; ?>
+
+namespace <?php echo $namespace; ?>;
+
+use Talleu\TriggerMapping\Contract\MySQLTriggerInterface;
+
+class <?php echo $class_name; ?> implements MySQLTriggerInterface
+{
+    public static function getTrigger(): string
+    {
+        return <<<SQL
+            CREATE OR ALTER TRIGGER <?= $trigger_name ?> ON <?= $table_name ?> AFTER <?= $events ?> AS BEGIN
+    <?php if (!empty($content)): ?>
+        <?= '            ' . str_replace("\n", "\n            ", trim($content)) ?>
+            END
+        SQL;
+    <?php else: ?>
+            -- TODO: Add your SQL logic here
+            -- Example: SET NEW.updated_at = NOW();
+            SELECT 'Sample Instead of trigger' as [Message]
+            END
+        SQL;
+    <?php endif; ?>
+    }
+}

--- a/src/Symfony/Maker/Resources/skeleton/sql/sqlserver_trigger.tpl.php
+++ b/src/Symfony/Maker/Resources/skeleton/sql/sqlserver_trigger.tpl.php
@@ -1,0 +1,8 @@
+CREATE OR ALTER TRIGGER <?= $trigger_name ?> 
+ON <?= $table_name ?> 
+AFTER <?= $events ?> 
+AS BEGIN
+    -- TODO: Add your SQL logic here
+    -- Example: SET NEW.updated_at = NOW();
+    SELECT 'Sample Instead of trigger' as [Message]
+END;

--- a/tests/Application/Entity/SqlServerCorrectlyMappedEntity.php
+++ b/tests/Application/Entity/SqlServerCorrectlyMappedEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Talleu\TriggerMapping\Tests\Application\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Talleu\TriggerMapping\Attribute\Trigger;
+
+#[ORM\Entity]
+#[Trigger(name: "correctly_mapped_trigger", on: ["UPDATE"], when: "AFTER", scope: "ROW")]
+class SqlServerCorrectlyMappedEntity
+{
+    #[ORM\Id, ORM\GeneratedValue, ORM\Column]
+    private ?int $id = null;
+}

--- a/tests/Application/Entity/SqlServerUpdateSchemaTestEntity.php
+++ b/tests/Application/Entity/SqlServerUpdateSchemaTestEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\TriggerMapping\Tests\Application\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Talleu\TriggerMapping\Attribute\Trigger;
+use Talleu\TriggerMapping\Tests\Application\Triggers\SqlServerTriggerClass;
+
+#[ORM\Entity]
+#[Trigger(
+    name: "trg_update_schema_test",
+    on: ["UPDATE"],
+    when: "AFTER",
+    scope: "ROW",
+    className: SqlServerTriggerClass::class
+)]
+class SqlServerUpdateSchemaTestEntity
+{
+    #[ORM\Id, ORM\GeneratedValue, ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $name = null;
+}

--- a/tests/Application/Triggers/SqlServerTriggerClass.php
+++ b/tests/Application/Triggers/SqlServerTriggerClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Talleu\TriggerMapping\Tests\Application\Triggers;
+
+use Talleu\TriggerMapping\Contract\MySQLTriggerInterface;
+
+class SqlServerTriggerClass implements MySQLTriggerInterface
+{
+    public static function getTrigger(): string
+    {
+        return <<<SQL
+            CREATE OR ALTER TRIGGER trg_update_schema_test
+            ON sql_server_update_schema_test_entity
+            AFTER INSERT 
+            AS BEGIN
+                -- La logique d'un trigger SQL Server va ici.
+                -- Voici un exemple simple et valide :
+                SELECT 'Sample Instead of trigger' as [Message]
+            END
+        SQL;
+    }
+}

--- a/tests/Application/config/packages/doctrine.yaml
+++ b/tests/Application/config/packages/doctrine.yaml
@@ -1,6 +1,9 @@
 doctrine:
   dbal:
     url: '%env(resolve:DATABASE_URL)%'
+
+    options:
+      TrustServerCertificate: yes
   orm:
     auto_generate_proxy_classes: true
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware

--- a/tests/Functional/AbstractTriggerValidateSchemaTestCase.php
+++ b/tests/Functional/AbstractTriggerValidateSchemaTestCase.php
@@ -14,6 +14,7 @@ use Talleu\TriggerMapping\Tests\Application\Entity\CorrectlyMappedEntity;
 use Talleu\TriggerMapping\Tests\Application\Entity\MissingInDbEntity;
 use Talleu\TriggerMapping\Tests\Application\Entity\MysqlCorrectlyMappedEntity;
 use Talleu\TriggerMapping\Tests\Application\Entity\NoTriggerEntity;
+use Talleu\TriggerMapping\Tests\Application\Entity\SqlServerCorrectlyMappedEntity;
 use Talleu\TriggerMapping\Tests\Application\Entity\TriggerBadParamsEntity;
 
 abstract class AbstractTriggerValidateSchemaTestCase extends KernelTestCase
@@ -39,6 +40,7 @@ abstract class AbstractTriggerValidateSchemaTestCase extends KernelTestCase
             CorrectlyMappedEntity::class,
             MissingInDbEntity::class,
             MysqlCorrectlyMappedEntity::class,
+            SqlServerCorrectlyMappedEntity::class,
             TriggerBadParamsEntity::class,
         ]);
     }

--- a/tests/Functional/AbstractTriggersSchemaUpdateTestCase.php
+++ b/tests/Functional/AbstractTriggersSchemaUpdateTestCase.php
@@ -6,6 +6,7 @@ namespace Talleu\TriggerMapping\Tests\Functional;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -76,10 +77,22 @@ abstract class AbstractTriggersSchemaUpdateTestCase extends KernelTestCase
 
     protected function triggerExists(string $triggerName): bool
     {
-        $platform = $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ? 'postgresql' : 'mysql';
+        switch ($this->connection->getDatabasePlatform()::class) {
+            case PostgreSQLPlatform::class:
+                $platform = 'postgresql';
+                break;
+            case SQLServerPlatform::class:
+                $platform = 'sqlsrv';
+                break;
+            default:
+                $platform = 'mysql';
+                break;
+        }
 
         if ($platform === 'mysql') {
             $sql = "SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_NAME = ?";
+        } elseif ($platform === 'sqlsrv') { 
+            $sql = "SELECT COUNT(*) FROM sys.triggers AS T WHERE T.name = ?";
         } else {
             $sql = "SELECT COUNT(*) FROM pg_trigger WHERE tgname = ?";
         }

--- a/tests/Functional/SqlServer/MakeTriggerTest.php
+++ b/tests/Functional/SqlServer/MakeTriggerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Talleu\TriggerMapping\Tests\Functional\SqlServer;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Talleu\TriggerMapping\Tests\Application\Entity\NoTriggerEntity;
+use Talleu\TriggerMapping\Tests\Functional\AbstractMakeTriggerTestCase;
+
+final class MakeTriggerTest extends AbstractMakeTriggerTestCase
+{
+    public function testExecuteWithAllArguments(): void
+    {
+        $command = $this->application->find('make:trigger');
+        $commandTester = new CommandTester($command);
+        $triggerName = 'trg_make_test_sqlserver';
+
+        $reflection = new \ReflectionClass(NoTriggerEntity::class);
+        $filePath = $reflection->getFileName();
+        copy($filePath, str_replace('.php', '.original', $filePath));
+
+        $commandTester->execute([
+            'entity-class' => NoTriggerEntity::class,
+            'trigger-name' => $triggerName,
+            'on' => 'UPDATE',
+            'when' => 'AFTER',
+            'storage' => 'sql',
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+        $expectedSqlFile = $this->triggersDir .'/'. $triggerName . '.sql';
+        $this->assertFileExists($expectedSqlFile);
+
+        $entityContent = file_get_contents($filePath);
+        $this->assertStringContainsString('#[Trigger(', $entityContent);
+        $this->assertStringContainsString("name: '$triggerName'", $entityContent);
+        $this->assertStringContainsString("on: ['UPDATE']", $entityContent);
+    }
+
+    public function createDirs(): void
+    {
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($this->triggersDir);
+    }
+}

--- a/tests/Functional/SqlServer/TriggerSchemaValidateTest.php
+++ b/tests/Functional/SqlServer/TriggerSchemaValidateTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Talleu\TriggerMapping\Tests\Functional\SqlServer;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Talleu\TriggerMapping\Tests\Application\Entity\MissingInDbEntity;
+use Talleu\TriggerMapping\Tests\Application\Entity\NoTriggerEntity;
+use Talleu\TriggerMapping\Tests\Application\Entity\SqlServerCorrectlyMappedEntity;
+use Talleu\TriggerMapping\Tests\Application\Entity\TriggerBadParamsEntity;
+use Talleu\TriggerMapping\Tests\Functional\AbstractTriggerValidateSchemaTestCase;
+
+final class TriggerSchemaValidateTest extends AbstractTriggerValidateSchemaTestCase
+{
+    protected function getCreateTriggerSql(string $triggerName, string $tableName, string $when, string $events): string
+    {
+        return <<<SQL
+            CREATE OR ALTER TRIGGER {$triggerName}
+            ON {$tableName}
+            AFTER {$events} 
+            AS BEGIN
+                -- Dummy logic for test trigger
+                SELECT 'Sample Instead of trigger' as [Message]
+            END
+        SQL;
+    }
+
+    public function testCorrectlyMappedEntity(): void
+    {
+        $sql = $this->getCreateTriggerSql(
+            'correctly_mapped_trigger',
+            'sql_server_correctly_mapped_entity',
+            'AFTER',
+            'UPDATE',
+        );
+        $this->executeSql($sql);
+
+        $command = $this->application->find('triggers:schema:validate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--entity' => SqlServerCorrectlyMappedEntity::class]);
+        print_r($commandTester->getDisplay());
+        $commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('The database triggers are in sync with the mapping.', $commandTester->getDisplay());
+    }
+
+    public function testMissingIndDb(): void
+    {
+        $command = $this->application->find('triggers:schema:validate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--entity' => MissingInDbEntity::class]);
+
+        $this->assertEquals($commandTester->getStatusCode(), Command::FAILURE);
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'not sync with the current mapping'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'missing_in_db_trigger'));
+    }
+
+    public function testBadParams(): void
+    {
+        $sql = $this->getCreateTriggerSql(
+            'bad_params_trigger',
+            'trigger_bad_params_entity',
+            'AFTER',
+            'INSERT',
+        );
+        $this->executeSql($sql);
+
+        $command = $this->application->find('triggers:schema:validate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--entity' => TriggerBadParamsEntity::class]);
+        $this->assertEquals($commandTester->getStatusCode(), Command::FAILURE);
+
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'not sync with the current mapping'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'parameters that do not match the database'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'bad_params_trigger'));
+    }
+
+    public function testMissingInMapping(): void
+    {
+        $sql = $this->getCreateTriggerSql(
+            'correctly_mapped_trigger',
+            'no_trigger_entity',
+            'AFTER',
+            'UPDATE',
+        );
+        $this->executeSql($sql);
+
+        $command = $this->application->find('triggers:schema:validate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--entity' => NoTriggerEntity::class]);
+
+        $this->assertEquals($commandTester->getStatusCode(), Command::FAILURE);
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'not sync with the current mapping'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'not mapped'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'correctly_mapped_trigger'));
+    }
+
+    public function testTableWithoutEntity(): void
+    {
+        $this->executeSql("CREATE TABLE useless_table (name VARCHAR(255) NOT NULL);");
+
+        $sql = $this->getCreateTriggerSql(
+            'useless_trigger',
+            'useless_table',
+            'AFTER',
+            'UPDATE',
+        );
+        $this->executeSql($sql);
+
+        $command = $this->application->find('triggers:schema:validate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'useless_trigger concerns a table'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'useless_table'));
+        $this->assertTrue(str_contains($commandTester->getDisplay(), 'Doctrine'));
+    }
+}

--- a/tests/Functional/SqlServer/TriggersMappingUpdateTest.php
+++ b/tests/Functional/SqlServer/TriggersMappingUpdateTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Talleu\TriggerMapping\Tests\Functional\SqlServer;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Talleu\TriggerMapping\Tests\Application\Entity\UpdateMappingTestEntity;
+use Talleu\TriggerMapping\Tests\Functional\AbstractTriggersMappingUpdateTestCase;
+
+final class TriggersMappingUpdateTest extends AbstractTriggersMappingUpdateTestCase
+{
+    protected function getCreateTriggerSql(string $triggerName, string $tableName, string $when, string $events, ?string $functionName = null): string
+    {
+        $eventName = $when === 'AFTER' ? 'AFTER' : 'FOR';
+        return <<<SQL
+            CREATE OR ALTER TRIGGER {$triggerName}
+            ON {$tableName}
+            {$eventName} {$events} 
+            AS BEGIN
+                -- Dummy logic for test trigger
+                SELECT 'Sample Instead of trigger' as [Message]
+            END
+        SQL;
+    }
+
+    public function testUnmappedTriggerAddAttribute(): void
+    {
+        $this->createSchemaForEntities([UpdateMappingTestEntity::class]);
+        $sql = $this->getCreateTriggerSql(
+            'trigger_to_map',
+            'update_mapping_test_entity',
+            'AFTER',
+            'INSERT'
+        );
+        $this->executeSql($sql);
+
+        $command = $this->application->find('triggers:mapping:update');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--apply' => true]);
+        $commandTester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Mapping update process finished successfully', $commandTester->getDisplay());
+        $reflection = new \ReflectionClass(UpdateMappingTestEntity::class);
+        $filePath = $reflection->getFileName();
+        $fileContent = file_get_contents($filePath);
+
+        $this->assertStringContainsString('#[Trigger(name:', $fileContent);
+        $this->assertStringContainsString('name: \'trigger_to_map\'', $fileContent);
+        $this->assertStringContainsString('on: [\'INSERT\']', $fileContent);
+        $this->assertStringContainsString('when: \'AFTER\'', $fileContent);
+        // We assert that the function parameter is NOT present for MySQL
+        $this->assertStringNotContainsString('function:', $fileContent);
+    }
+}

--- a/tests/Functional/SqlServer/TriggersSchemaUpdateTest.php
+++ b/tests/Functional/SqlServer/TriggersSchemaUpdateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\TriggerMapping\Tests\Functional\SqlServer;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Talleu\TriggerMapping\Tests\Application\Entity\SqlServerUpdateSchemaTestEntity;
+use Talleu\TriggerMapping\Tests\Functional\AbstractTriggersSchemaUpdateTestCase;
+
+final class TriggersSchemaUpdateTest extends AbstractTriggersSchemaUpdateTestCase
+{
+    public function testExecuteApplyMode(): void
+    {
+        $this->createSchemaForEntities([SqlServerUpdateSchemaTestEntity::class]);
+
+        $this->assertFalse($this->triggerExists('trg_update_schema_test'), "Pre-condition failed: Trigger 'trg_update_schema_test' should not exist before running the command.");
+        $command = $this->application->find('triggers:schema:update');
+        $commandTester = new CommandTester($command);
+
+        // Simulate the user typing "yes" to the confirmation prompt
+        $commandTester->setInputs(['yes']);
+        $commandTester->execute(['--force' => true, '--entity' => SqlServerUpdateSchemaTestEntity::class]);
+        $commandTester->assertCommandIsSuccessful();
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('Running in FORCE mode', $output);
+        $this->assertStringContainsString("Processing trigger trg_update_schema_test", $output);
+        $this->assertStringContainsString('Database schema updated successfully.', $output);
+        $this->assertTrue($this->triggerExists('trg_update_schema_test'), "Post-condition failed: Trigger 'trg_update_schema_test' should exist after running the command.");
+    }
+
+    protected function createTriggerFile(string $fileName, string $content): void
+    {
+        // TODO: Implement createTriggerFile() method.
+    }
+}


### PR DESCRIPTION
SQL support implementation, should resolve #9 

```
- Add SQL Server service in Docker compose
- Add PHPUnit tests for SQL Server
- Update several classes for SQL Server support
- Add new templates for SQL Server
```

For now, I've just implemented the `AFTER` event trigger as the `BEFORE` is not available in SQL Server. Should be great to support the `INSTEAD OF` later